### PR TITLE
Expand README with schedule and links

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,27 @@
+=======
+Credits
+=======
+
+Project Coordinators
+--------------------
+
+* Mark Piper <mark.piper@colorado.edu>
+* Irina Overeem <irina.overeem@colorado.edu>
+* Benajmin Campforts <benjamin.campforts@colorado.edu>
+* Nicole Gasparini <ngaspari@tulane.edu>
+
+Contributors
+------------
+
+* Jordan Adams
+* Katy Barnhart
+* Albert Kettner
+* Nathan Lyons
+* Margaux Mouchene
+* Mariela Perignon
+* Katherine Ratliff
+* Kang Wang
+
+If you have contributed to the ESPIn course material and your name is missing,
+please send an email to the coordinators, or open a pull request
+for this page in the `ESPIn repository <https://github.com/csdms/espin>`_.

--- a/CODE-OF-CONDUCT.rst
+++ b/CODE-OF-CONDUCT.rst
@@ -1,0 +1,83 @@
+Contributor Covenant Code of Conduct
+====================================
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Our Responsibilities
+--------------------
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at csdms@colorado.edu. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the
+`Contributor Covenant <https://www.contributor-covenant.org>`_, version 1.4,
+available at
+`<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>`_.
+
+For answers to common questions about this code of conduct, see
+`<https://www.contributor-covenant.org/faq>`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,103 @@
+.. highlight:: shell
+
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+----------------------
+
+Report Bugs
+~~~~~~~~~~~
+
+Report bugs at https://github.com/csdms/espin/issues.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+~~~~~~~~
+
+Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
+wanted" is open to whoever wants to implement it.
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the GitHub issues for features. Anything tagged with "enhancement"
+and "help wanted" is open to whoever wants to implement it.
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+ESPIn could always use more documentation, whether as part of the
+official docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+
+The best way to send feedback is to file an issue at
+https://github.com/csdms/espin/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+Get Started!
+------------
+
+Ready to contribute? Here's how to set up ESPIn for local development.
+
+1. Fork the ESPIn repo on GitHub.
+1. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/espin.git
+
+1. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+1. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+1. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+3. The pull request should work for Python 3.6, 3.7, and 3.8.
+   Make sure that the tests pass for all supported Python versions.
+
+Deploying
+---------
+
+A reminder for the maintainers on how to deploy.
+Make sure all your changes are committed (including an entry in HISTORY.rst).
+Then run::
+
+$ git tag v<major>.<minor>.<patch>
+$ git push
+$ git push --tags

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Topics in this repository include:
 
 * Version control with git and GitHub
 * [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) >> [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main)
-* Landlab
+* [Landlab](./lessons/landlab/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-green.svg"></a>
 * The Pytho Modeling Toolkit (pymt)
 * Software engineering basics
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Topics covered include:
 
 | Topic | Run on...
 | ----- | ---------
-| [Introduction to the Shell](./lessons/shell/index.md) | 
+| [Introduction to the Shell](./lessons/shell/index.md) | local computer
 | [Python Basics](./lessons/python/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
 | [Python for ESP Scientists](./lessons/python/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-| [Version Control with git and GitHub](./lessons/git/index.md) |
+| [Version Control with git and GitHub](./lessons/git/index.md) | local computer
 | [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
 | [Landlab](./lessons/landlab/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
 | [The Python Modeling Toolkit (pymt)](./lessons/python/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpymt%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-| [Software Engineering Basics](./lessons/git/index.md) |
+| [Permamodel Toolkit](./lessons/pymt/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpymt%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+| [Software Engineering Basics](./lessons/git/index.md) | local computer
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ held 2020 August 12-14, 17-19.
 ## Topics
 
 The full ESPIn schedule is [here](https://docs.google.com/document/d/1bSZgtlyyylG9OgPExBG6n2QR4Fhl5SNR_5hXbrfYUSg/edit#heading=h.mg7jb2qru7hf).
-Topics in this repository include:
+Topics covered include:
 
-* [Introduction to the Shell](./lessons/shell/index.md)
-* [Python Basics](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Python for ESP Scientists](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Version Control with git and GitHub](./lessons/git/index.md)
-* [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Landlab](./lessons/landlab/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [The Python Modeling Toolkit (pymt)](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpymt%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Software Engineering Basics](./lessons/git/index.md)
+| Topic | Run on...
+| ----- | ---------
+| [Introduction to the Shell](./lessons/shell/index.md) | 
+| [Python Basics](./lessons/python/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+| [Python for ESP Scientists](./lessons/python/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+| [Version Control with git and GitHub](./lessons/git/index.md) |
+| [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+| [Landlab](./lessons/landlab/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+| [The Python Modeling Toolkit (pymt)](./lessons/python/index.ipynb) | <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpymt%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+| [Software Engineering Basics](./lessons/git/index.md) |
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # ESPIn
 
-Course material for the Earth Surface Processes Institute (ESPIn) summer school.
+Course material for the Earth Surface Processes Institute (ESPIn) summer school,
+held 2020 August 12-14, 17-19.
+
 
 ## Topics
 
@@ -10,10 +12,11 @@ The full ESPIn schedule is [here](https://docs.google.com/document/d/1bSZgtlyyyl
 Topics in this repository include:
 
 * [Introduction to the shell](./lessons/shell/index.md)
-* [Python basics](./lessons/python/index.ipynb) >> Run on the [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=master)
-* Python for ESP scientists
+* [Python basics](./lessons/python/index.ipynb) >> Run on the [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main)
+* [Python for ESP scientists](./lessons/python/index.ipynb) <a href="https://travis-ci.org/csdms/pymt"><img alt="Build Status" src="./media/jupyterhub.png"></a>
+
 * Version control with git and GitHub
-* The Basic Model Interface (BMI)
+* [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) >> [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main)
 * Landlab
 * The Pytho Modeling Toolkit (pymt)
 * Software engineering basics

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ The full ESPIn schedule is [here](https://docs.google.com/document/d/1bSZgtlyyyl
 Topics in this repository include:
 
 * [Introduction to the shell](./lessons/shell/index.md)
-* [Python basics](./lessons/python/index.ipynb) >> Run on the [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main)
-* [Python for ESP scientists](./lessons/python/index.ipynb) <a href="https://travis-ci.org/csdms/pymt"><img alt="Build Status" src="./media/jupyterhub.png"></a>
-
-* Version control with git and GitHub
-* [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) >> [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main)
-* [Landlab](./lessons/landlab/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-green.svg"></a>
-* The Pytho Modeling Toolkit (pymt)
-* Software engineering basics
+* [Python basics](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [Python for ESP scientists](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [Version control with git and GitHub](./lessons/git/index.md)
+* [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [Landlab](./lessons/landlab/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [The Python Modeling Toolkit (pymt)](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpymt%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [Software engineering basics](./lessons/git/index.md)
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ held 2020 August 12-14, 17-19.
 The full ESPIn schedule is [here](https://docs.google.com/document/d/1bSZgtlyyylG9OgPExBG6n2QR4Fhl5SNR_5hXbrfYUSg/edit#heading=h.mg7jb2qru7hf).
 Topics in this repository include:
 
-* [Introduction to the shell](./lessons/shell/index.md)
-* [Python basics](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Python for ESP scientists](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Version control with git and GitHub](./lessons/git/index.md)
+* [Introduction to the Shell](./lessons/shell/index.md)
+* [Python Basics](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [Python for ESP Scientists](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
+* [Version Control with git and GitHub](./lessons/git/index.md)
 * [The Basic Model Interface (BMI)](./lessons/bmi/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fbmi%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
 * [Landlab](./lessons/landlab/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Flandlab%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
 * [The Python Modeling Toolkit (pymt)](./lessons/python/index.ipynb) <a href="https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpymt%2Findex.ipynb&branch=main"><img alt="Run on CSDMS JupyterHub" src="https://img.shields.io/badge/CSDMS-JupyterHub-orange.svg"></a>
-* [Software engineering basics](./lessons/git/index.md)
+* [Software Engineering Basics](./lessons/git/index.md)
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -4,6 +4,44 @@
 
 Course material for the Earth Surface Processes Institute (ESPIn) summer school.
 
+## Topics
+
+The full ESPIn schedule is [here](https://docs.google.com/document/d/1bSZgtlyyylG9OgPExBG6n2QR4Fhl5SNR_5hXbrfYUSg/edit#heading=h.mg7jb2qru7hf).
+Topics in this repository include:
+
+* Introduction to the shell
+* Python basics
+* Python for ESP scientists
+* Version control with git and GitHub
+* The Basic Model Interface (BMI)
+* Landlab
+* The Pytho Modeling Toolkit (pymt)
+* Software engineering basics
+
+
+## Requirements
+
+* Laptop
+* Web browser
+* Coffee (optional, but recommended)
+
+
+## Links
+
+* [Landlab documentation](https://landlab.readthedocs.io/en/v2_dev/)
+* [Basic Model Interface (BMI) documentation](http://bmi.readthedocs.io)
+* [Python Modeling Toolkit (pymt) documentation](http://pymt.readthedocs.io)
+* [Community Surface Dynamics Modeling System (CSDMS)](http://csdms.colorado.edu)
+
+
+## The ESPIn team
+
+* [Irina Overeem](https://www.colorado.edu/geologicalsciences/irina-overeem)
+* [Benjamin Campforts](https://instaar.colorado.edu/people/benjamin-campforts/)
+* [Nicole Gasparini](https://sse.tulane.edu/eens/faculty/gasparini)
+* [Leilani Arthurs](https://www.colorado.edu/geologicalsciences/leilani-arthurs)
+* [Mark Piper](https://instaar.colorado.edu/people/mark-piper/)
+
 
 ESPIn is supported by the National Science Foundation
 under Award Numbers

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Course material for the Earth Surface Processes Institute (ESPIn) summer school.
 The full ESPIn schedule is [here](https://docs.google.com/document/d/1bSZgtlyyylG9OgPExBG6n2QR4Fhl5SNR_5hXbrfYUSg/edit#heading=h.mg7jb2qru7hf).
 Topics in this repository include:
 
-* Introduction to the shell
-* Python basics
+* [Introduction to the shell](./lessons/shell/index.md)
+* [Python basics](./lessons/python/index.ipynb) >> Run on the [CSDMS JupyterHub](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fpython%2Findex.ipynb&branch=master)
 * Python for ESP scientists
 * Version control with git and GitHub
 * The Basic Model Interface (BMI)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Topics covered include:
 * [Mark Piper](https://instaar.colorado.edu/people/mark-piper/)
 
 
+ESPIn is a community-focused project;
+[contributions](./CONTRIBUTING.rst) that follow
+the [contributor code of conduct](./CODE-OF-CONDUCT.rst) are welcomed,
+and are [acknowledged](./AUTHORS.rst).
+All ESPIn course material is open source,
+released under the [MIT License](./LICENSE).
+
 ESPIn is supported by the National Science Foundation
 under Award Numbers
 [1924259](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924259) and


### PR DESCRIPTION
This PR expands the README to include topics, links, the project team, and instructions for contributing.

This fixes #5.