### PR TITLE
Use URL for logo image

### DIFF
--- a/lessons/best-practices/collaboration-etiquette.md
+++ b/lessons/best-practices/collaboration-etiquette.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Collaborative projects ("Gitiquette")
 

--- a/lessons/best-practices/continuous-integration.md
+++ b/lessons/best-practices/continuous-integration.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Continuous integration with Travis CI
 

--- a/lessons/best-practices/index.md
+++ b/lessons/best-practices/index.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Best Practices in Software Development
 

--- a/lessons/best-practices/unit-testing.md
+++ b/lessons/best-practices/unit-testing.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Unit testing with pytest
 

--- a/lessons/conda/index.md
+++ b/lessons/conda/index.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Anaconda and conda
 

--- a/lessons/git/configuring-git.md
+++ b/lessons/git/configuring-git.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Configuring git
 

--- a/lessons/git/git-collaborative-project.md
+++ b/lessons/git/git-collaborative-project.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Version control in a collaborative project
 

--- a/lessons/git/git-single-user-project.md
+++ b/lessons/git/git-single-user-project.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Version control in a single-user project
 

--- a/lessons/git/index.md
+++ b/lessons/git/index.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Introduction to version control with git and GitHub
 

--- a/lessons/shell/creating-things.md
+++ b/lessons/shell/creating-things.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Creating things
 

--- a/lessons/shell/files-and-directories.md
+++ b/lessons/shell/files-and-directories.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Files and directories
 

--- a/lessons/shell/finding-things.md
+++ b/lessons/shell/finding-things.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Finding things
 

--- a/lessons/shell/getting-things.md
+++ b/lessons/shell/getting-things.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Getting things from elsewhere
 

--- a/lessons/shell/index.md
+++ b/lessons/shell/index.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Introduction to the shell
 

--- a/lessons/shell/pipes-and-filters.md
+++ b/lessons/shell/pipes-and-filters.md
@@ -1,4 +1,4 @@
-![ESPIn logo](../../media/ESPIn.png)
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
 
 # Pipes and filters
 


### PR DESCRIPTION
This PR updates all lessons written in Markdown to use the URL to the logo image rather than a relative path to the top-level media directory. This allows the logo to be displayed when viewed on GitHub.