### PR TITLE
Update continuous integration lesson

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
 
-  build:
-  # We want to run on external PRs, but not on our own internal PRs as they'll be run
-  # by the push to the branch. Without this if check, checks are duplicated since
-  # internal PRs match both the push and pull_request events.
+  test:
+    # We want to run on external PRs, but not on our own internal PRs as they'll
+    # be run by the push to the branch. Without this if check, checks are
+    # duplicated since internal PRs match both the push and pull_request events.
     if:
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
This PR includes updates to the CI lesson, moving it from Travis CI to GitHub Actions. I forgot to include this in #40.