### PR TITLE
Update best practices lesson

### DIFF
--- a/lessons/best-practices/collaboration-etiquette.md
+++ b/lessons/best-practices/collaboration-etiquette.md
@@ -95,3 +95,4 @@ ___
 
 [Best Practices in Software Development](./index.md) |
 Previous: [Continuous integration](./continuous-integration.md)
+Next: [FAIR practices for research software](./fair-practices.md)

--- a/lessons/best-practices/collaboration-etiquette.md
+++ b/lessons/best-practices/collaboration-etiquette.md
@@ -5,24 +5,13 @@
 This lesson describes some best practices
 for working on a collaborative project<sup>[1](#cp-fn1)</sup>.
 
-When working on a collaborative project,
-the following workflow is recommended:
+Some recommendations:
 
-1. issue
-1. fork
-1. branch
-1. commit
-1. test
-1. pull request
-1. merge
+* Use issues. A good issue should describe th problem. If an error is thrown,
+  the text of the error message should be included. Don't screenshot the
+  error--it's not searchable, and the text of the error can't be copy/pasted
+  easily.
 
-Based on this workflow, some recommendations:
-
-* A good issue should describe the problem. If an error is thrown, the
-  text of the error message should be included. Don't screenshot the
-  error--it's not searchable, and the text of the error can't be
-  copy/pasted easily.
-  
 * A reproduce case should be provided for the issue, showing the steps
   that lead up to the error.
 
@@ -59,8 +48,8 @@ Based on this workflow, some recommendations:
 
 * It's a good idea to request a reviewer on a pull request.
 
-* It's good to review the the test results from Travis CI on each pull
-  request, even when successful.
+* It's good to review the the test results from continuous integration on each
+  pull request, even when successful.
 
 * If you're the repository owner, only merge pull requests when all
   tests pass. The default branch to always be clean and working.
@@ -105,4 +94,4 @@ the result of mistakes I've made.
 ___
 
 [Best Practices in Software Development](./index.md) |
-Previous: [Continuous integration with Travis CI](./continuous-integration.md)
+Previous: [Continuous integration](./continuous-integration.md)

--- a/lessons/best-practices/fair-practices.md
+++ b/lessons/best-practices/fair-practices.md
@@ -1,0 +1,47 @@
+![ESPIn logo](https://github.com/csdms/espin/blob/main/media/ESPIn2021.png)
+
+# FAIR practices for research software
+
+*Allen Lee (Arizona State University)*
+
+FAIR is
+
+* Findable
+* Accessible
+* Interoperable
+* Reproducible
+
+What steps can you take to make your code FAIR?
+
+1. License your code
+
+    https://choosealicense.com/
+
+1. Document your code
+
+    - narrative documentation and descriptive metadata
+    - explicit, versioned, software, system, and data dependencies community /
+      domain specific standards
+
+1. Archive your code
+
+    - TRUSTed digital repository or software registry (e.g., Zenodo for GitHub repositories)
+
+1. Use version control (the hard part)
+
+    - descriptive commit messages
+    - clear provenance (goals: small focused commits, clean history, linkages
+      between commits, issues, and pull requests, continuous integration)
+
+## Resources
+
+* [Towards FAIR principles for research software](https://doi.org/10.3233/DS-190026)
+* [FAIR & Research Software](https://csdms.colorado.edu/wiki/Presenters-0548)
+* [Toward the Geoscience Paper of the Future](https://doi.org/10.1002/2015EA000136)
+* [Dealing with Software Collapse](https://doi.org/10.1109/MCSE.2019.2900945) (and original [blog post](http://blog.khinsen.net/posts/2017/01/13/sustainable-software-and-reproducible-research-dealing-with-software-collapse/))
+* [Software Deposit: What to deposit](https://doi.org/10.5281/zenodo.1327325)
+
+___
+
+[Best Practices in Software Development](./index.md) |
+Previous: [Collaborative projects ("Gitiquette")](./collaboration-etiquette.md)

--- a/lessons/best-practices/index.md
+++ b/lessons/best-practices/index.md
@@ -34,4 +34,4 @@ This lesson continues in the following sections.
 1. [Unit testing with pytest](./unit-testing.md)
 1. [Continuous integration](./continuous-integration.md)
 1. [Collaborative projects ("Gitiquette")](./collaboration-etiquette.md)
-
+1. [FAIR practices for research software](./fair-practices.md)

--- a/lessons/best-practices/index.md
+++ b/lessons/best-practices/index.md
@@ -32,6 +32,6 @@ for the work of ESP scientists.
 This lesson continues in the following sections.
 
 1. [Unit testing with pytest](./unit-testing.md)
-1. [Continuous integration with Travis CI](./continuous-integration.md)
+1. [Continuous integration](./continuous-integration.md)
 1. [Collaborative projects ("Gitiquette")](./collaboration-etiquette.md)
 

--- a/lessons/best-practices/unit-testing.md
+++ b/lessons/best-practices/unit-testing.md
@@ -179,4 +179,4 @@ ___
 
 [Best Practices in Software Development](./index.md) |
 Previous: [index](./index.md) |
-Next: [Continuous integration with Travis CI](./continuous-integration.md)
+Next: [Continuous integration](./continuous-integration.md)


### PR DESCRIPTION
This PR updates the best practices lesson: touching up text, removing stray references to Travis CI, and adding a section with @alee's FAIR practices for reserach software.