### PR TITLE
Maintenance on shell lesson

### DIFF
--- a/lessons/shell/creating-things.md
+++ b/lessons/shell/creating-things.md
@@ -18,7 +18,7 @@ use the `mkdir` command to make a new directory:
 ```
 $ mkdir new
 $ ls
-data-shell  data-shell.zip  new
+shell-lesson-data  shell-lesson-data.zip  new
 ```
 Change to the new directory and get a listing:
 ```
@@ -86,7 +86,7 @@ $ mv haiku-1 ~/Desktop
 $ ls
 haiku
 $ ls ~/Desktop/
-data-shell  data-shell.zip  haiku-1  new
+shell-lesson-data  shell-lesson-data.zip  haiku-1  new
 ```
 Note that **haiku-1** has been moved from the **new** directory to **Desktop**.
 
@@ -117,7 +117,7 @@ $ mv haiku ..
 $ cd ..
 $ rmdir new
 $ ls
-data-shell  data-shell.zip  haiku
+shell-lesson-data  shell-lesson-data.zip  haiku
 ```
 As `rm` removes files,
 the `rmdir` command removes directories.

--- a/lessons/shell/files-and-directories.md
+++ b/lessons/shell/files-and-directories.md
@@ -41,13 +41,13 @@ We can drill down through directories by providing arguments to `ls`.
 For example, to see the contents of the **Desktop** directory, type:
 ```
 $ ls Desktop
-data-shell  data-shell.zip
+shell-lesson-data  shell-lesson-data.zip
 ```
 You can see the sample files we downloaded earlier.
 We can drill further; for example, to see into the directory containing
 the sample files:
 ```
-$ ls Desktop/data-shell
+$ ls Desktop/shell-lesson-data
 creatures  molecules           notes.txt  solar.pdf
 data       north-pacific-gyre  pizza.cfg  writing
 ```
@@ -158,7 +158,7 @@ hit the `Tab` key,
 and the shell will attempt to complete the command.
 For example,
 from the **Desktop** directory,
-try listing the contents of **data-shell**
+try listing the contents of **shell-lesson-data**
 by typing the first few characters, then hitting the `Tab` key:
 ```
 $ ls da
@@ -172,11 +172,11 @@ printing to the terminal the branch-leaf structure from a point
 in the filesystem.
 For example,
 from the **Desktop** directory,
-view the contents of the **data-shell/writing** directory 
+view the contents of the **shell-lesson-data/writing** directory 
 with `tree`:
 ```
-$ tree data-shell/writing
-data-shell/writing/
+$ tree shell-lesson-data/writing
+shell-lesson-data/writing/
 |-- data
 |   |-- LittleWomen.txt
 |   |-- one.txt

--- a/lessons/shell/finding-things.md
+++ b/lessons/shell/finding-things.md
@@ -6,8 +6,8 @@ The `grep` command is a powerful tool for matching patterns in files.
 Let's use it to look for unicorns in our files:
 ```
 $ grep -r unicorn .
-./data-shell/creatures/unicorn.dat:1:COMMON NAME: unicorn
-Binary file ./data-shell.zip matches
+./shell-lesson-data/creatures/unicorn.dat:1:COMMON NAME: unicorn
+Binary file ./shell-lesson-data.zip matches
 ```
 The `r` option performs a recursive search,
 starting at the current directory,
@@ -17,7 +17,7 @@ To omit binary files from the search,
 use the `I` option:
 ```
 $ grep -rI unicorn .
-./data-shell/creatures/unicorn.dat:1:COMMON NAME: unicorn
+./shell-lesson-data/creatures/unicorn.dat:1:COMMON NAME: unicorn
 ```
 
 To search only within the current directory,
@@ -26,8 +26,8 @@ Let's find all instances of the word "octane" in the files
 in the current directory:
 ```
 $ grep octane *
-grep: data-shell: Is a directory
-Binary file data-shell.zip matches
+grep: shell-lesson-data: Is a directory
+Binary file shell-lesson-data.zip matches
 molecule_pdb_lengths:4:  30 octane.txt
 molecule_pdb_lengths.bak:4:  30 octane.pdb
 ```
@@ -37,11 +37,11 @@ The `find` command recursively locates all files that match a search pattern.
 Let's find all the files with the extension **.txt**:
 ```
 $ find . -iname "*.txt"
-./data-shell/data/amino-acids.txt
-./data-shell/data/animal-counts/animals.txt
-./data-shell/data/animals.txt
-./data-shell/data/morse.txt
-./data-shell/data/planets.txt
+./shell-lesson-data/data/amino-acids.txt
+./shell-lesson-data/data/animal-counts/animals.txt
+./shell-lesson-data/data/animals.txt
+./shell-lesson-data/data/morse.txt
+./shell-lesson-data/data/planets.txt
 ...
 ```
 The search started at the current directory, `.`
@@ -53,10 +53,10 @@ under the current directory:
 ```
 $ find . -type d
 .
-./data-shell
-./data-shell/creatures
-./data-shell/data
-./data-shell/data/animal-counts
+./shell-lesson-data
+./shell-lesson-data/creatures
+./shell-lesson-data/data
+./shell-lesson-data/data/animal-counts
 ...
 ```
 

--- a/lessons/shell/getting-things.md
+++ b/lessons/shell/getting-things.md
@@ -9,11 +9,11 @@ and the shell commands provide more flexibility.
 For example,
 the URL from which we downloaded the Software Carpentry sample data files is
 
-> https://swcarpentry.github.io/shell-novice/data/data-shell.zip
+> https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip
 
 Use the `curl` command to download this file programmatically:
 ```
-$ curl https://swcarpentry.github.io/shell-novice/data/data-shell.zip -o data-shell-1.zip
+$ curl https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip -o shell-lesson-data-1.zip
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  566k  100  566k    0     0  2037k      0 --:--:-- --:--:-- --:--:-- 2045k
@@ -25,8 +25,8 @@ so as not to clobber the existing file.
 Verify that the file was downloaded:
 ```
 $ ls -l *.zip
--rw-r--r--  1 mpiper  staff  580102 Jul 30 16:22 data-shell-1.zip
--rw-r--r--@ 1 mpiper  staff  580102 Jul 28 16:05 data-shell.zip
+-rw-r--r--  1 mpiper  staff  580102 Jul 30 16:22 shell-lesson-data-1.zip
+-rw-r--r--@ 1 mpiper  staff  580102 Jul 28 16:05 shell-lesson-data.zip
 ```
 
 `curl` can do very cool things with wildcards, as well.
@@ -35,25 +35,25 @@ Visit its (lengthy) man page to see all the options.
 The `wget` command provides functionality similar to `curl`,
 but with a slightly simpler call.
 ```
-$ wget https://swcarpentry.github.io/shell-novice/data/data-shell.zip
---2020-07-30 16:36:01--  https://swcarpentry.github.io/shell-novice/data/data-shell.zip
+$ wget https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip
+--2020-07-30 16:36:01--  https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip
 Resolving swcarpentry.github.io... 185.199.109.153, 185.199.108.153, 185.199.111.153, ...
 Connecting to swcarpentry.github.io|185.199.109.153|:443... connected.
 HTTP request sent, awaiting response... 200 OK
 Length: 580102 (567K) [application/zip]
-Saving to: ‘data-shell.zip.1’
+Saving to: ‘shell-lesson-data.zip.1’
 
-data-shell.zip.1     100%[======================>] 566.51K  --.-KB/s    in 0.09s
+shell-lesson-data.zip.1     100%[======================>] 566.51K  --.-KB/s    in 0.09s
 
-2020-07-30 16:36:01 (6.34 MB/s) - ‘data-shell.zip.1’ saved [580102/580102]
+2020-07-30 16:36:01 (6.34 MB/s) - ‘shell-lesson-data.zip.1’ saved [580102/580102]
 ```
 
 Verify that the file was downloaded:
 ```
 $ ll *zip*
--rw-r--r--  1 mpiper  staff  580102 Jul 30 16:22 data-shell-1.zip
--rw-r--r--@ 1 mpiper  staff  580102 Jul 28 16:05 data-shell.zip
--rw-r--r--@ 1 mpiper  staff  580102 Jul  1 01:44 data-shell.zip.1
+-rw-r--r--  1 mpiper  staff  580102 Jul 30 16:22 shell-lesson-data-1.zip
+-rw-r--r--@ 1 mpiper  staff  580102 Jul 28 16:05 shell-lesson-data.zip
+-rw-r--r--@ 1 mpiper  staff  580102 Jul  1 01:44 shell-lesson-data.zip.1
 ```
 
 
@@ -64,24 +64,24 @@ it's more efficient to transfer a compressed file over the internet.
 
 The example files downloaded from Software Carpentry
 are compressed into a *zip archive*.
-We've already uncompressed these files into the **data-shell** directory
+We've already uncompressed these files into the **shell-lesson-data** directory
 through the operating system.
 Let's remove these files and instead uncompress the zip file using the shell.
 
-First, remove the existing **data-shell** directory:
+First, remove the existing **shell-lesson-data** directory:
 ```
-$ rm -rf data-shell
+$ rm -rf shell-lesson-data
 ```
-Then use the `unzip` command to uncompress **data-shell.zip**:
+Then use the `unzip` command to uncompress **shell-lesson-data.zip**:
 ```
-$ unzip data-shell.zip
-Archive:  data-shell.zip
-   creating: data-shell/
-  inflating: data-shell/pizza.cfg
-  inflating: data-shell/.bash_profile
-   creating: data-shell/molecules/
-  inflating: data-shell/molecules/ethane.pdb
-  inflating: data-shell/molecules/cubane.pdb
+$ unzip shell-lesson-data.zip
+Archive:  shell-lesson-data.zip
+   creating: shell-lesson-data/
+  inflating: shell-lesson-data/pizza.cfg
+  inflating: shell-lesson-data/.bash_profile
+   creating: shell-lesson-data/molecules/
+  inflating: shell-lesson-data/molecules/ethane.pdb
+  inflating: shell-lesson-data/molecules/cubane.pdb
   ...
 ```
 
@@ -89,11 +89,11 @@ While zip files are common on Windows,
 *tar* files that use the more efficient gzip and bzip2 compressors
 are more common on Unix-based operating systems.
 
-Let's compress the **data-shell** directory
+Let's compress the **shell-lesson-data** directory
 with `tar` and compare file sizes:
 ```
-$ tar -czf data-shell.tar.gz data-shell
-$ tar -cjf data-shell.tar.bz2 data-shell
+$ tar -czf shell-lesson-data.tar.gz shell-lesson-data
+$ tar -cjf shell-lesson-data.tar.bz2 shell-lesson-data
 ```
 In these commands,
 the `c` option creates an archive file,
@@ -103,10 +103,10 @@ The **.tar.gz** and **.tar.bz2** extensions are used by convention.
 
 Check sizes:
 ```
-$ ls -lh data-shell.*
--rw-r--r--  1 mpiper  staff   393K Jul 31 15:42 data-shell.tar.bz2
--rw-r--r--  1 mpiper  staff   518K Jul 31 15:41 data-shell.tar.gz
--rw-r--r--@ 1 mpiper  staff   567K Jul 28 16:05 data-shell.zip
+$ ls -lh shell-lesson-data.*
+-rw-r--r--  1 mpiper  staff   393K Jul 31 15:42 shell-lesson-data.tar.bz2
+-rw-r--r--  1 mpiper  staff   518K Jul 31 15:41 shell-lesson-data.tar.gz
+-rw-r--r--@ 1 mpiper  staff   567K Jul 28 16:05 shell-lesson-data.zip
 ```
 Note that bzip2 < gzip < zip compression.
 In the directory listing, recall the `l` option provides a long listing.
@@ -114,12 +114,12 @@ The `h` option provides "human readable" output.
 
 Uncompress these tarballs with:
 ```
-tar -xf data-shell.tar.gz
-tar -xf data-shell.tar.bz2
+tar -xf shell-lesson-data.tar.gz
+tar -xf shell-lesson-data.tar.bz2
 ```
 Here, the `x` option is for uncompressing the archive file.
 In each case,
-the existing **data-shell** directory was clobbered
+the existing **shell-lesson-data** directory was clobbered
 when the archive was uncompressed.
 
 

--- a/lessons/shell/index.md
+++ b/lessons/shell/index.md
@@ -23,10 +23,10 @@ which you'll need to follow the lesson.
 
 Please:
 
-1. Download [data-shell.zip](https://swcarpentry.github.io/shell-novice/data/data-shell.zip) and move the file to your Desktop.
+1. Download [shell-lesson-data.zip](https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip) and move the file to your Desktop.
 1. Unzip/extract the file (ask your instructor if you need help with this step).
 
-You should end up with a new folder called **data-shell** on your Desktop.
+You should end up with a new folder called **shell-lesson-data** on your Desktop.
 
 
 ## Open a terminal
@@ -36,7 +36,7 @@ with the operating system of a computer
 through terse text commands.
 
 * Linux: terminal or xterm
-* macOS: Terminal.app (built-in) or [iTerm.app](https://www.iterm2.com/) (better)
+* macOS: Terminal.app (built-in) or [iTerm.app](https://www.iterm2.com/)
 * Windows: Git Bash Shell in [Git for Windows](https://gitforwindows.org/)
 
 At this time,

--- a/lessons/shell/pipes-and-filters.md
+++ b/lessons/shell/pipes-and-filters.md
@@ -14,11 +14,11 @@ a text editor.
 
 The **haiku** file is short.
 For longer files, a *pager* is more appropriate to use.
-Let's change to the **data-shell/data** directory
+Let's change to the **shell-lesson-data/data** directory
 and view the contents of the file **planets.txt**
 with the pager `more`:
 ```
-$ cd data-shell/data/
+$ cd shell-lesson-data/data/
 $ ls
 amino-acids.txt  animals.txt  morse.txt  planets.txt  sunspot.txt
 animal-counts    elements     pdb        salmon.txt
@@ -87,9 +87,9 @@ it takes the output from one command
 and feeds them as input to another command.
 For example,
 get the first five lines of the long directory listing
-for the **data-shell/data/pdb** directory:
+for the **shell-lesson-data/data/pdb** directory:
 ```
-$ ls -l data-shell/data/pdb | head -5
+$ ls -l shell-lesson-data/data/pdb | head -5
 total 208
 -rw-r--r--. 1 mpiper csdms  1516 Aug  7  2019 aldrin.pdb
 -rw-r--r--. 1 mpiper csdms   306 Aug  7  2019 ammonia.pdb
@@ -98,7 +98,7 @@ total 208
 ```
 Actually, how many files are in this directory?
 ```
-$ ls -1 data-shell/data/pdb/ | wc -l
+$ ls -1 shell-lesson-data/data/pdb/ | wc -l
 48
 ```
 In this example,
@@ -109,14 +109,14 @@ The greater than symbol `>` performs the *redirect* action:
 it takes the output from a command
 and redirects it from the terminal to a file.
 For example,
-there are a set of data files in the **data-shell/molecules** directory:
+there are a set of data files in the **shell-lesson-data/molecules** directory:
 ```
-$ ls data-shell/molecules/
+$ ls shell-lesson-data/molecules/
 cubane.pdb  ethane.pdb  methane.pdb  octane.pdb  pentane.pdb  propane.pdb
 ```
 Let's find the lengths of these files and store them in a new file:
 ```
-$ cd data-shell/molecules/
+$ cd shell-lesson-data/molecules/
 $ wc -l *.pdb > ~/Desktop/molecule_pdb_lengths
 $ cd -
 /home/mpiper/Desktop
@@ -136,9 +136,9 @@ here, it's used to match any file that ends with **.pdb**.
 Related to the asterisk is the question mark `?`,
 which is used to match a single character in a filename.
 For example,
-change to the **data-shell** directory and view its contents:
+change to the **shell-lesson-data** directory and view its contents:
 ```
-$ cd data-shell/
+$ cd shell-lesson-data/
 $ ls
 creatures  molecules           notes.txt  solar.pdf
 data       north-pacific-gyre  pizza.cfg  writing


### PR DESCRIPTION
Software Carpentry changed the name of the shell examples data file. This PR updates the shell lesson to reflect this change.